### PR TITLE
Update to the new streamData endpoint

### DIFF
--- a/blaseballPlayback.py
+++ b/blaseballPlayback.py
@@ -33,7 +33,7 @@ class TColors:
 class BlaseballRecorder:
 	def __init__(self, filepath=None, uri=None):
 		self.filepath = filepath or "blaseballGame"
-		self.uri = uri or "https://www.blaseball.com/events/streamGameData"
+		self.uri = uri or "https://www.blaseball.com/events/streamData"
 		self.day_mode = False
 		self.skip_days = 0
 		self.messages = []
@@ -51,7 +51,7 @@ class BlaseballRecorder:
 			now = datetime.now()
 			time_since_start = now - self.start_time
 			data = json.loads(message.data)
-			cut_data = data["value"].copy()
+			cut_data = data["value"]["games"].copy()
 			lut = cut_data.pop("lastUpdateTime", -1)
 			if lut < self.last_update_time:
 				skips += 1
@@ -171,7 +171,7 @@ class BlaseballStreamer:
 					message = last_message_body
 				else:
 					last_message_body = message
-				self.http_games = message["value"]["schedule"]
+				self.http_games = message["value"]["games"]["schedule"]
 				next_message += 1
 			else:
 				await asyncio.sleep(0.05)


### PR DESCRIPTION
On Aug 27, Game Band consolidated `events/streamGameData` and other streams into a single endpoint, `events/streamData`. The old streamGameData data (previously just `values`) now lives in the `value.games` field. Updated that in the main script so the default recording URL works, and the parts of the script that reference game fields are pointed at the right location.

Also, the `lastUpdateTime` field was removed from game stream data in that update. BlaseballPlayback references `lastUpdateTime` in several places, but I'm not totally sure what it's doing or how best to replace it with the fields we do have, and it seems to work ok without touching it. So I didn't update anything around `lastUpdateTime`, but you might want to revisit that yourself.

(FYI, that endpoint apparently also auto-rate-limits itself once the games are all over, which might be relevant to reconnect and timeout logic.)